### PR TITLE
fix(seo): replace placeholder AdSense pub ID in app-ads.txt

### DIFF
--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,1 +1,1 @@
-google.com, pub-0000000000000000, DIRECT, f08c47fec0942fa0
+google.com, pub-9347276405837051, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Replace dummy pub-0000... with real AdSense publisher ID (pub-9347276405837051) to match rizzman.ai and moruk.ai. Unblocks AdMob verification.